### PR TITLE
Add artifactregistry to APIs to be enabled to avoid error

### DIFF
--- a/demo-startup.sh
+++ b/demo-startup.sh
@@ -8,7 +8,8 @@ gcloud services enable sourcerepo.googleapis.com \
     container.googleapis.com \
     redis.googleapis.com \
     cloudresourcemanager.googleapis.com \
-    servicenetworking.googleapis.com
+    servicenetworking.googleapis.com \
+    artifactregistry.googleapis.com
 
 # Give the Cloud Build service account permission to modify Cloud Deploy 
 # resources and create releases to deploy on GKE. These permissions are 


### PR DESCRIPTION
./demo-startup.sh breaks towards the end if AR API is not enabled.
Can't find error message now, will add when I do.